### PR TITLE
Update OpenDDLParserUtils.h

### DIFF
--- a/include/openddlparser/OpenDDLParserUtils.h
+++ b/include/openddlparser/OpenDDLParserUtils.h
@@ -243,7 +243,7 @@ bool isComment( T *in, T *end ) {
         if ( in+1!=end ) {
             if ( *( in+1 )=='/' ) {
                 char *drive( ( in+2 ) );
-                if ( isUpperCase<T>( *drive )||isLowerCase<T>( *drive )&&*( drive+1 )=='/' )  {
+                if ( (isUpperCase<T>( *drive )||isLowerCase<T>( *drive ))&&*( drive+1 )=='/' )  {
                     return false;
                 } else {
                     return true;


### PR DESCRIPTION
operator precedence.  Code probably meant " if drive[0] is either an upper or lower case letter - AND - drive[1] is '/' ".  Without the parentheses && binds before ||, giving it a strange meaning.