### PR TITLE
remove memory leak

### DIFF
--- a/code/DDLNode.cpp
+++ b/code/DDLNode.cpp
@@ -68,14 +68,17 @@ DDLNode::DDLNode( const std::string &type, const std::string &name, size_t idx, 
 }
 
 DDLNode::~DDLNode() {
-    releaseDataType<Property>( m_properties );
-    releaseDataType<Value>( m_value );
+    delete m_properties;
+    delete m_value;
     releaseReferencedNames( m_references );
 
     delete m_dtArrayList;
     m_dtArrayList = ddl_nullptr;
     if( s_allocatedNodes[ m_idx ] == this ) {
         s_allocatedNodes[ m_idx ] = ddl_nullptr;
+    }
+    for(DDLNode* child: m_children){
+        delete child;
     }
 }
 
@@ -126,6 +129,8 @@ const std::string &DDLNode::getName() const {
 }
 
 void DDLNode::setProperties( Property *prop ) {
+    if(m_properties!=ddl_nullptr)
+        delete m_properties;
     m_properties = prop;
 }
 

--- a/code/DDLNode.cpp
+++ b/code/DDLNode.cpp
@@ -77,8 +77,8 @@ DDLNode::~DDLNode() {
     if( s_allocatedNodes[ m_idx ] == this ) {
         s_allocatedNodes[ m_idx ] = ddl_nullptr;
     }
-    for(DDLNode* child: m_children){
-        delete child;
+    for(size_t i = 0 ; i<m_children.size();i++){
+        delete m_children[i];
     }
 }
 

--- a/code/OpenDDLCommon.cpp
+++ b/code/OpenDDLCommon.cpp
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -----------------------------------------------------------------------------------------------*/
 #include <openddlparser/OpenDDLCommon.h>
 #include <openddlparser/DDLNode.h>
+#include <openddlparser/Value.h>
 
 BEGIN_ODDLPARSER_NS
 
@@ -84,7 +85,14 @@ Name::~Name() {
     m_id = ddl_nullptr;
 }
 
-Reference::Reference()
+Name::Name( const Name &name ){
+    m_type=name.m_type;
+    m_id=new Text(name.m_id->m_buffer,name.m_id->m_len);
+}
+
+
+
+    Reference::Reference()
 : m_numRefs( 0 )
 , m_referencedName( ddl_nullptr ) {
     // empty
@@ -96,8 +104,16 @@ Reference::Reference( size_t numrefs, Name **names )
     if ( numrefs > 0 ) {
         m_referencedName = new Name *[ numrefs ];
         for ( size_t i = 0; i < numrefs; i++ ) {
-            Name *name = new Name( names[ i ]->m_type, names[ i ]->m_id );
-            m_referencedName[ i ] = name;
+            m_referencedName[ i ] = names[i];
+        }
+    }
+}
+Reference::Reference(const Reference &ref) {
+    m_numRefs=ref.m_numRefs;
+    if(m_numRefs!=0){
+        m_referencedName = new Name*[m_numRefs];
+        for ( size_t i = 0; i < m_numRefs; i++ ) {
+            m_referencedName[i] = new Name(*ref.m_referencedName[i]);
         }
     }
 }
@@ -107,6 +123,7 @@ Reference::~Reference() {
         delete m_referencedName[ i ];
     }
     m_numRefs = 0;
+    delete [] m_referencedName;
     m_referencedName = ddl_nullptr;
 }
 
@@ -135,21 +152,30 @@ Property::Property( Text *id )
 }
 
 Property::~Property() {
-    m_key = ddl_nullptr;
-    m_value = ddl_nullptr;
-    m_ref = ddl_nullptr;;
-    m_next = ddl_nullptr;;
+    delete m_key;
+    if(m_value!=ddl_nullptr)
+        delete m_value;
+    if(m_ref!=ddl_nullptr)
+        delete(m_ref);
+    if(m_next!=ddl_nullptr)
+        delete m_next;
 }
 
 DataArrayList::DataArrayList()
 : m_numItems( 0 )
 , m_dataList( ddl_nullptr )
-, m_next( ddl_nullptr ) {
+, m_next( ddl_nullptr )
+, m_refs(ddl_nullptr)
+, m_numRefs(0){
     // empty
 }
 
 DataArrayList::~DataArrayList() {
-    // empty
+    delete m_dataList;
+    if(m_next!=ddl_nullptr)
+        delete m_next;
+    if(m_refs!=ddl_nullptr)
+        delete m_refs;
 }
 
 size_t DataArrayList::size() {

--- a/code/OpenDDLParser.cpp
+++ b/code/OpenDDLParser.cpp
@@ -105,7 +105,6 @@ static DDLNode *createDDLNode( Text *id, OpenDDLParser *parser ) {
     const std::string type( id->m_buffer );
     DDLNode *parent( parser->top() );
     DDLNode *node = DDLNode::create( type, "", parent );
-
     return node;
 }
 
@@ -193,10 +192,11 @@ size_t OpenDDLParser::getBufferSize() const {
 void OpenDDLParser::clear() {
     m_buffer.resize( 0 );
     if( ddl_nullptr != m_context ) {
-        m_context->m_root = ddl_nullptr;
+        delete m_context;
+        m_context=ddl_nullptr;
     }
 
-    DDLNode::releaseNodes();
+//    DDLNode::releaseNodes();
 }
 
 bool OpenDDLParser::parse() {
@@ -212,7 +212,7 @@ bool OpenDDLParser::parse() {
 
     // do the main parsing
     char *current( &m_buffer[ 0 ] );
-    char *end( &m_buffer[ m_buffer.size() - 1 ] + 1 );
+    char *end( &m_buffer[m_buffer.size() - 1 ] + 1 );
     size_t pos( current - &m_buffer[ 0 ] );
     while( pos < m_buffer.size() ) {
         current = parseNextNode( current, end );
@@ -271,13 +271,16 @@ char *OpenDDLParser::parseHeader( char *in, char *end ) {
         } else {
             std::cerr << "nullptr returned by creating DDLNode." << std::endl;
         }
+        delete id;
 
 		Name *name(ddl_nullptr);
 		in = OpenDDLParser::parseName(in, end, &name);
         if( ddl_nullptr != name && ddl_nullptr != node ) {
             const std::string nodeName( name->m_id->m_buffer );
             node->setName( nodeName );
+            delete name;
         }
+
 
 		Property *first(ddl_nullptr);
 		in = lookForNextToken(in, end);
@@ -431,7 +434,6 @@ DDLNode *OpenDDLParser::popNode() {
 
     DDLNode *topNode( top() );
     m_stack.pop_back();
-
     return topNode;
 }
 
@@ -535,8 +537,7 @@ char *OpenDDLParser::parseIdentifier( char *in, char *end, Text **id ) {
     }
 
     const size_t len( idLen );
-    Text *newId = new Text( start, len );
-    *id = newId;
+    *id = new Text( start, len );
 
     return in;
 }
@@ -862,7 +863,8 @@ char *OpenDDLParser::parseProperty( char *in, char *end, Property **prop ) {
                     ( *prop )->m_ref = ref;
                 }
             }
-        }
+        } else
+            delete id;
     }
 
     return in;

--- a/code/Value.cpp
+++ b/code/Value.cpp
@@ -110,7 +110,17 @@ Value::Value( ValueType type )
 }
 
 Value::~Value() {
-    // empty
+    if(m_data!=ddl_nullptr) {
+        if (m_type == ddl_ref ) {
+            Reference *tmp = (Reference *) m_data;
+            if (tmp != ddl_nullptr)
+                delete tmp;
+        }else
+            delete[] m_data;
+
+    }
+    if(m_next!=ddl_nullptr)
+        delete m_next;
 }
 
 void Value::setBool( bool value ) {
@@ -273,13 +283,7 @@ void Value::setRef( Reference *ref ) {
                 delete [] m_data;
             }
 
-            m_data = new unsigned char[ sizeof( Reference ) ];
-            Reference *myRef = ( Reference * ) m_data;
-            myRef->m_numRefs = ref->m_numRefs;
-            myRef->m_referencedName =  new Name *[ myRef->m_numRefs ];
-            for ( size_t i = 0; i < myRef->m_numRefs; i++ ) {
-                myRef->m_referencedName[ i ] = new Name( ref->m_referencedName[ i ]->m_type, ref->m_referencedName[ i ]->m_id );
-            }
+            m_data = (unsigned char*) new Reference(*ref);
         }
     }
 }
@@ -366,7 +370,6 @@ Value *ValueAllocator::allocPrimData( Value::ValueType type, size_t len ) {
     }
 
     Value *data = new Value( type );
-    data->m_type = type;
     switch( type ) {
         case Value::ddl_bool:
             data->m_size = sizeof( bool );
@@ -405,10 +408,10 @@ Value *ValueAllocator::allocPrimData( Value::ValueType type, size_t len ) {
             data->m_size = sizeof( double );
             break;
         case Value::ddl_string:
-            data->m_size = sizeof( char );
+            data->m_size = sizeof( char )*(len+1);
             break;
         case Value::ddl_ref:
-            data->m_size = sizeof( char );
+            data->m_size = 0;
             break;
         case Value::ddl_none:
         case Value::ddl_types_max:
@@ -417,12 +420,8 @@ Value *ValueAllocator::allocPrimData( Value::ValueType type, size_t len ) {
     }
 
     if( data->m_size ) {
-        size_t len1( len );
-        if( Value::ddl_string == type ) {
-            len1++;
-        }
-        data->m_size *= len1;
         data->m_data = new unsigned char[ data->m_size ];
+        ::memset(data->m_data,0,data->m_size);
     }
 
     return data;

--- a/demo/main.cpp
+++ b/demo/main.cpp
@@ -119,7 +119,8 @@ int main( int argc, char *argv[] ) {
                 theExporter.exportContext( theParser.getContext(), exportFilename );
             }
         }
+        delete [] buffer;
     }
-
+    fclose(fileStream);
     return 0;
 }

--- a/include/openddlparser/OpenDDLCommon.h
+++ b/include/openddlparser/OpenDDLCommon.h
@@ -148,12 +148,12 @@ struct DLL_ODDLPARSER_EXPORT Name {
     ///	@param  type    [in] The name type.
     ///	@param  id      [in] The id.
     Name( NameType type, Text *id );
-
+    Name( const Name &name );
     ///	@brief  The destructor.
     ~Name();
 
 private:
-    Name( const Name & ) ddl_no_copy;
+
     Name &operator = ( const Name& ) ddl_no_copy;
 };
 
@@ -164,7 +164,7 @@ struct DLL_ODDLPARSER_EXPORT Reference {
 
     ///	@brief  The default constructor.
     Reference();
-
+    Reference( const Reference &ref );
     ///	@brief  The constructor with an array of ref names.
     /// @param  numrefs     [in] The number of ref names.
     /// @param  names       [in] The ref names.
@@ -178,7 +178,6 @@ struct DLL_ODDLPARSER_EXPORT Reference {
     size_t sizeInBytes();
 
 private:
-    Reference( const Reference & ) ddl_no_copy;
     Reference &operator = ( const Reference & ) ddl_no_copy;
 };
 

--- a/include/openddlparser/OpenDDLParser.h
+++ b/include/openddlparser/OpenDDLParser.h
@@ -47,7 +47,7 @@ struct Property;
 template<class T>
 inline
 T *lookForNextToken( T *in, T *end ) {
-    while( ( isSpace( *in ) || isNewLine( *in ) || ',' == *in ) && ( in != end ) ) {
+    while( ( in != end ) && ( isSpace( *in ) || isNewLine( *in ) || ',' == *in ) ) {
         in++;
     }
     return in;

--- a/test/DDLNodeTest.cpp
+++ b/test/DDLNodeTest.cpp
@@ -43,6 +43,7 @@ TEST_F( DDLNodeTest, createDDLNodeTest ) {
     }
     EXPECT_TRUE( ddl_nullptr != myNode );
     EXPECT_TRUE( success );
+    delete myNode;
 }
 
 TEST_F( DDLNodeTest, accessTypeTest ) {
@@ -55,6 +56,7 @@ TEST_F( DDLNodeTest, accessTypeTest ) {
     static const std::string type2 = "type2";
     myNode->setType( type2 );
     EXPECT_EQ( type2, myNode->getType() );
+    delete myNode;
 }
 
 TEST_F( DDLNodeTest, accessNameTest ) {
@@ -67,6 +69,7 @@ TEST_F( DDLNodeTest, accessNameTest ) {
     static const std::string name2 = "test";
     myNode->setName( name2 );
     EXPECT_EQ( name2, myNode->getName() );
+    delete myNode;
 }
 
 TEST_F( DDLNodeTest, accessParentTest ) {
@@ -90,6 +93,9 @@ TEST_F( DDLNodeTest, accessParentTest ) {
     // check if the child node is not the parent node ( bug )
     EXPECT_EQ( name1, myChilds[ 0 ]->getName() );
     EXPECT_EQ( name1, myChilds[ 1 ]->getName() );
+
+    delete parentNode;
+
 }
 
 TEST_F( DDLNodeTest, accessPropertiesDDLNodeTest ) {
@@ -100,6 +106,7 @@ TEST_F( DDLNodeTest, accessPropertiesDDLNodeTest ) {
     Property *first = new Property( id );
     node->setProperties( first );
     EXPECT_EQ( first, node->getProperties() );
+    delete node;
 }
 
 TEST_F( DDLNodeTest, hasPropertyTest ) {
@@ -114,6 +121,7 @@ TEST_F( DDLNodeTest, hasPropertyTest ) {
     node->setProperties( first );
     found = node->hasProperty( "test" );
     EXPECT_TRUE( found );
+    delete node;
 }
 
 TEST_F( DDLNodeTest, hasPropertiesTest ) {
@@ -125,7 +133,7 @@ TEST_F( DDLNodeTest, hasPropertiesTest ) {
     Property *first = new Property( id );
     node->setProperties( first );
     EXPECT_TRUE( node->hasProperties() );
-
+    delete node;
 }
 
 TEST_F( DDLNodeTest, findPropertyByNameTest ) {
@@ -140,6 +148,7 @@ TEST_F( DDLNodeTest, findPropertyByNameTest ) {
     node->setProperties( first );
     prop = node->findPropertyByName( "test" );
     EXPECT_EQ( first, prop );
+    delete node;
 }
 
 TEST_F( DDLNodeTest, accessValueTest ) {
@@ -150,6 +159,7 @@ TEST_F( DDLNodeTest, accessValueTest ) {
     Value *myValue( new Value( Value::ddl_bool ) );
     myNode->setValue( myValue );
     EXPECT_EQ( myValue, myNode->getValue() );
+    delete myNode;
 }
 
 TEST_F( DDLNodeTest, accessDataArrayListTest ) {
@@ -160,6 +170,7 @@ TEST_F( DDLNodeTest, accessDataArrayListTest ) {
     DataArrayList *dtArrayList( new DataArrayList );
     myNode->setDataArrayList( dtArrayList );
     EXPECT_EQ( dtArrayList, myNode->getDataArrayList() );
+    delete myNode;
 }
 
 TEST_F( DDLNodeTest, accessReferencesTest ) {
@@ -170,6 +181,7 @@ TEST_F( DDLNodeTest, accessReferencesTest ) {
     Reference *ref = new Reference;
     myNode->setReferences( ref );
     EXPECT_EQ( ref, myNode->getReferences() );
+    delete myNode;
 }
 
 END_ODDLPARSER_NS

--- a/test/OpenDDLCommonTest.cpp
+++ b/test/OpenDDLCommonTest.cpp
@@ -134,7 +134,6 @@ TEST_F( OpenDDLCommonTest, sizeAdatArrayListTest ) {
     EXPECT_EQ( 1, list->size() );
 
     delete list;
-    delete listNext;
 }
 
 TEST_F( OpenDDLCommonTest, sizeInBytesReferenceTest ) {
@@ -143,10 +142,12 @@ TEST_F( OpenDDLCommonTest, sizeInBytesReferenceTest ) {
     Reference *ref1( new Reference( 1, &name ) );
     size_t size( ref1->sizeInBytes() );
     EXPECT_EQ( 4, size );
+    delete ref1;
 
     Reference *ref2( new Reference( 0, ddl_nullptr ) );
     size = ref2->sizeInBytes();
     EXPECT_EQ( 0, size );
+    delete ref2;
 }
 
 END_ODDLPARSER_NS

--- a/test/OpenDDLDefectsTest.cpp
+++ b/test/OpenDDLDefectsTest.cpp
@@ -45,6 +45,8 @@ TEST_F( OpenDDLDefectsTest, Issue20_WrongColorNodeParsing ) {
     ASSERT_FALSE( ddl_nullptr == in );
     ASSERT_FALSE( ddl_nullptr == data );
     ASSERT_EQ( 3, numValues );
+    delete data;
+    delete refs;
 }
 
 TEST_F( OpenDDLDefectsTest, assimp_issues_665 ) {
@@ -176,6 +178,7 @@ TEST_F( OpenDDLDefectsTest, invalid_size_dataarraylist_issue_41 ) {
     
     list->m_dataList = new Value( Value::ddl_bool );
     EXPECT_EQ( 1, list->size() );
+    delete list;
 }
 
 END_ODDLPARSER_NS

--- a/test/OpenDDLExportTest.cpp
+++ b/test/OpenDDLExportTest.cpp
@@ -223,7 +223,8 @@ TEST_F( OpenDDLExportTest, writeFloatTest ) {
 
 TEST_F( OpenDDLExportTest, writeStringTest ) {
     OpenDDLExportMock myExport;
-    Value *v = ValueAllocator::allocPrimData( Value::ddl_string );
+    char tempString[] ="huhu";
+    Value *v = ValueAllocator::allocPrimData( Value::ddl_string,sizeof(tempString) );
     v->setString( "huhu" );
     bool ok( true );
     std::string statement;
@@ -246,11 +247,13 @@ TEST_F( OpenDDLExportTest, writeValueTypeTest ) {
     EXPECT_TRUE( ok );
     EXPECT_EQ( "int32", statement );
     statement.clear();
+    delete v_int32;
 
     Value *v_int32_array = ValueAllocator::allocPrimData( Value::ddl_int32 );
     ok = myExporter.writeValueTypeTester( v_int32_array->m_type, 10, statement );
     EXPECT_TRUE( ok );
     EXPECT_EQ( "int32[10]", statement );
+    delete v_int32_array;
 }
 
 TEST_F( OpenDDLExportTest, writePropertiesTest ) {
@@ -273,6 +276,7 @@ TEST_F( OpenDDLExportTest, writePropertiesTest ) {
     ok = myExporter.writePropertiesTester( m_root, statement );
     EXPECT_TRUE( ok );
     EXPECT_EQ( "(id.0 = 0, id.1 = 1)", statement );
+
 }
 
 TEST_F( OpenDDLExportTest, writeValueArrayTest ) {
@@ -303,6 +307,7 @@ TEST_F( OpenDDLExportTest, writeValueArrayTest ) {
     ok = myExporter.writeValueArrayTester( dataArrayList, statement );
     EXPECT_TRUE( ok );
     EXPECT_EQ( "{ 1, 2, 3 }", statement );
+    delete dataArrayList;
 }
 
 END_ODDLPARSER_NS

--- a/test/OpenDDLParserTest.cpp
+++ b/test/OpenDDLParserTest.cpp
@@ -145,6 +145,9 @@ TEST_F( OpenDDLParserTest, setLogCallbackTest ) {
 TEST_F( OpenDDLParserTest, accessBufferTest ) {
     static const size_t len = 100;
     char *buffer = new char[ len ];
+    for( size_t i = 0; i < len; i++ ) {
+        buffer[i]=(char)i;
+    }
     OpenDDLParser myParser;
     myParser.setBuffer( buffer, len );
     EXPECT_EQ( len, myParser.getBufferSize() );
@@ -175,6 +178,7 @@ TEST_F( OpenDDLParserTest, accessBufferTest ) {
     myParser.clear();
     EXPECT_EQ( 0, myParser.getBufferSize() );
     EXPECT_EQ( ddl_nullptr, myParser.getBuffer() );
+    delete [] buffer;
 }
 
 TEST_F( OpenDDLParserTest, clearTest ) {
@@ -198,6 +202,7 @@ TEST_F( OpenDDLParserTest, clearTest ) {
 
     myParser.clear();
     EXPECT_EQ( ddl_nullptr, myParser.getRoot() );
+
 }
 
 TEST_F( OpenDDLParserTest, normalizeBufferTest ) {
@@ -229,6 +234,7 @@ TEST_F( OpenDDLParserTest, parseIdentifierTest ) {
 
     res = strncmp( id->m_buffer, name1, len1 );
     EXPECT_EQ( 0, res );
+    delete id;
 
     size_t len2( 0 );
     char name2[] = " testname ", *end2( findEnd( name2, len2 ) );
@@ -236,6 +242,7 @@ TEST_F( OpenDDLParserTest, parseIdentifierTest ) {
     EXPECT_TRUE( id != ddl_nullptr );
     res = strncmp( id->m_buffer, name1, id->m_len );
     EXPECT_EQ( 0, res );
+    delete id;
 }
 
 TEST_F( OpenDDLParserTest, parseIdentifierWithLineBreakTest ) {
@@ -250,6 +257,7 @@ TEST_F( OpenDDLParserTest, parseIdentifierWithLineBreakTest ) {
     char name[] = "testname";
     res = strncmp( id->m_buffer, name, strlen( name ) );
     EXPECT_EQ( 0, res );
+    delete id;
 }
 
 TEST_F( OpenDDLParserTest, parseNameTest ) {
@@ -260,6 +268,7 @@ TEST_F( OpenDDLParserTest, parseNameTest ) {
     char *in = OpenDDLParser::parseName( name1, end1, &name );
     EXPECT_TRUE( name != ddl_nullptr );
     EXPECT_NE( name1, in );
+    delete name;
 }
 
 TEST_F( OpenDDLParserTest, parsePrimitiveDataTypeTest ) {
@@ -317,6 +326,7 @@ TEST_F( OpenDDLParserTest, parsePrimitiveArrayHexTest ) {
     Value::ValueType type( Value::ddl_none );
     char *in = OpenDDLParser::parseDataList( token, end, type, &data, numValues, &refs, numRefs );
     EXPECT_NE( in, token );
+    registerValueForDeletion(data);
 }
 
 TEST_F( OpenDDLParserTest, parsePrimitiveDataTypeWithInvalidArrayTest ) {
@@ -346,12 +356,14 @@ TEST_F( OpenDDLParserTest, parseReferenceTest ) {
     EXPECT_EQ( GlobalName, name->m_type );
     res = strncmp( name->m_id->m_buffer, "name1", strlen( "name1" ) );
     EXPECT_EQ( 0, res );
+    delete name;
 
     name = names[ 1 ];
     EXPECT_FALSE( ddl_nullptr == name );
     EXPECT_EQ( LocalName, name->m_type );
     res = strncmp( name->m_id->m_buffer, "name2", strlen( "name2" ) );
     EXPECT_EQ( 0, res );
+    delete name;
 }
 
 TEST_F( OpenDDLParserTest, copyReferenceTest ) {
@@ -383,6 +395,7 @@ TEST_F( OpenDDLParserTest, copyReferenceTest ) {
     EXPECT_EQ( LocalName, name->m_type );
     res = strncmp( name->m_id->m_buffer, "name2", strlen( "name2" ) );
     EXPECT_EQ( 0, res );
+    delete ref;
 }
 
 TEST_F( OpenDDLParserTest, parseBooleanLiteralTest ) {
@@ -449,6 +462,7 @@ TEST_F( OpenDDLParserTest, parseFloatingLiteralTest ) {
     ASSERT_FALSE( ddl_nullptr == data );
     EXPECT_EQ( Value::ddl_float, data->m_type );
     EXPECT_EQ(1.0f, data->getFloat() );
+    registerValueForDeletion(data);
 
     char token2[] = "-1.0f", *end2( findEnd( token2, len ) );
     out = OpenDDLParser::parseFloatingLiteral( token2, end2, &data );
@@ -456,6 +470,7 @@ TEST_F( OpenDDLParserTest, parseFloatingLiteralTest ) {
     ASSERT_FALSE( ddl_nullptr == data );
     EXPECT_EQ( Value::ddl_float, data->m_type );
     EXPECT_EQ( -1.0f, data->getFloat() );
+    registerValueForDeletion(data);
 }
 
 TEST_F( OpenDDLParserTest, parseStringLiteralTest ) {
@@ -471,6 +486,7 @@ TEST_F( OpenDDLParserTest, parseStringLiteralTest ) {
     std::string str( (char*) data->m_data );
     int res( ::strncmp( "teststring", str.c_str(), str.size() ) );
     EXPECT_EQ( 0, res );
+    registerValueForDeletion( data );
 }
 
 TEST_F( OpenDDLParserTest, parseHexaLiteralTest ) {
@@ -480,10 +496,10 @@ TEST_F( OpenDDLParserTest, parseHexaLiteralTest ) {
     char *in = OpenDDLParser::parseHexaLiteral( token1, end, &data );
     ASSERT_FALSE( ddl_nullptr == in );
     ASSERT_FALSE( ddl_nullptr == data );
-    registerValueForDeletion( data );
 
     uint64 v( data->getUnsignedInt64() );
     EXPECT_EQ( 1, v );
+    registerValueForDeletion(data);
 
     char token2[] = "0xff";
     end = findEnd( token2, len );
@@ -503,6 +519,7 @@ TEST_F( OpenDDLParserTest, parseHexaLiteralTest ) {
     v = data->getUnsignedInt64();
     EXPECT_EQ( ExpValue, v );
     registerValueForDeletion( data );
+
 }
 
 TEST_F( OpenDDLParserTest, parseFloatHexaLiteralTest ) {
@@ -512,6 +529,8 @@ TEST_F( OpenDDLParserTest, parseFloatHexaLiteralTest ) {
     char *in = OpenDDLParser::parseHexaLiteral( token1, end, &data );
     const float value( data->getFloat() );
     EXPECT_FLOAT_EQ( 1.0f, value );
+    registerValueForDeletion( data );
+
 }
 
 TEST_F( OpenDDLParserTest, parsePropertyTest ) {
@@ -525,6 +544,7 @@ TEST_F( OpenDDLParserTest, parsePropertyTest ) {
     ASSERT_FALSE( ddl_nullptr == prop->m_key );
     int res = strncmp( "lod", prop->m_key->m_buffer, prop->m_key->m_len );
     EXPECT_EQ( 0, res );
+    delete prop;
 
     char prop2[] = "key = \"angle\"", *end2( findEnd( prop2, len ) );
     in = OpenDDLParser::parseProperty( prop2, end2, &prop );
@@ -537,6 +557,7 @@ TEST_F( OpenDDLParserTest, parsePropertyTest ) {
     EXPECT_FALSE( ddl_nullptr == prop->m_value->m_data );
     res = strncmp( "angle", ( char* ) prop->m_value->m_data, prop->m_value->m_size );
     EXPECT_EQ( 0, res );
+    delete prop;
 }
 
 TEST_F( OpenDDLParserTest, parseDataArrayListTest ) {
@@ -556,7 +577,7 @@ TEST_F( OpenDDLParserTest, parseDataArrayListTest ) {
     EXPECT_NE( token, in );
     EXPECT_EQ( 3, numItems );
 
-    // todo: fix leak!
+    delete dtArrayList;
 }
 
 TEST_F( OpenDDLParserTest, getVersionTest ) {
@@ -587,12 +608,12 @@ TEST_F( OpenDDLParserTest, parseDataListTest ) {
     EXPECT_EQ( 4, countItems( data ) );
     EXPECT_TRUE( testValues( Value::ddl_int32, data, expValues ) );
     registerValueForDeletion( data );
+    delete refs;
 
     char token2[] = "{ \"string1\",\"string2\"}";
     end = findEnd( token2, len );
     in = OpenDDLParser::parseDataList( token2, end, type, &data, numValues, &refs, numRefs );
     ASSERT_FALSE( ddl_nullptr == data );
-    registerValueForDeletion( data );
 
     // check intrinsic list with strings
     EXPECT_EQ( 2, countItems( data ) );
@@ -607,6 +628,8 @@ TEST_F( OpenDDLParserTest, parseDataListTest ) {
         data = data->m_next;
         i++;
     }
+    registerValueForDeletion( data );
+    delete refs;
 }
 
 TEST_F( OpenDDLParserTest, parseDataArrayListWithArrayTest ) {
@@ -633,6 +656,7 @@ TEST_F( OpenDDLParserTest, parseDataArrayListWithArrayTest ) {
     EXPECT_EQ( 16, dataArrayList->m_numItems );
 
     EXPECT_NE('}', *in );
+    delete dataArrayList;
 }
 
 
@@ -652,6 +676,8 @@ TEST_F( OpenDDLParserTest, parseDataArrayListWithRefsTest ) {
     in = OpenDDLParser::parseDataList( in, end, type, &val, numValues, &refs, numRefs );
     EXPECT_EQ( 1, numRefs );
     EXPECT_FALSE( ddl_nullptr == refs );
+    delete refs;
+    registerValueForDeletion(val);
 }
 
 static void validateDataArray( Value *value, size_t expectedNumItems  ) {
@@ -703,6 +729,7 @@ TEST_F( OpenDDLParserTest, parseDataArrayListWithMultibleArrayTest ) {
             nextValue = nextDataArrayList->m_dataList;
         }
     }
+    delete dataArrayList;
 }
 
 TEST_F( OpenDDLParserTest, pushTest ) {
@@ -714,6 +741,7 @@ TEST_F( OpenDDLParserTest, pushTest ) {
     theParser.pushNode( node );
     current = theParser.top();
     EXPECT_EQ( node, current );
+    delete node;
 }
 
 TEST_F( OpenDDLParserTest, popTest ) {
@@ -746,6 +774,9 @@ TEST_F( OpenDDLParserTest, popTest ) {
 
     current = theParser.top();
     EXPECT_EQ( ddl_nullptr, current );
+    delete node1;
+    delete node2;
+    delete node3;
 }
 
 TEST_F( OpenDDLParserTest, parseHexValueLiteralTest ) {
@@ -758,6 +789,7 @@ TEST_F( OpenDDLParserTest, parseHexValueLiteralTest ) {
     EXPECT_NE( &token[ 0 ], next );
     const float val = data->getFloat();
     EXPECT_FLOAT_EQ( 1.0f, val );
+    registerValueForDeletion( data );
 }
 
 

--- a/test/ValueTest.cpp
+++ b/test/ValueTest.cpp
@@ -35,12 +35,8 @@ protected:
     }
 
     virtual void TearDown() {
-        Value *current( m_start ), *tmp( ddl_nullptr );
-        while( ddl_nullptr != current ) {
-            tmp = current;
-            current = current->m_next;
-            delete tmp;
-        }
+        if(m_start!=ddl_nullptr)
+            delete m_start;
     }
 
     Value *createValueList() {
@@ -83,6 +79,7 @@ TEST_F( ValueTest, ValueAccessStringTest ) {
     data->setString( text );
     int res = ::strncmp( text.c_str(), data->getString(), text.size() );
     EXPECT_EQ( 0, res );
+    delete data;
 }
 
 TEST_F( ValueTest, ValueAccessNextTest ) {
@@ -95,6 +92,7 @@ TEST_F( ValueTest, ValueAccessNextTest ) {
 
     data->setNext( dataNext );
     EXPECT_EQ( dataNext, data->getNext() );
+    delete data;
 }
 
 TEST_F( ValueTest, InitIteratorTest ) {
@@ -213,7 +211,7 @@ TEST_F( ValueTest, accessReferenceTest ) {
     Reference *ref = new Reference;
     Name *name = new Name( GlobalName, new Text( "hello", 4 ) );
     ref->m_numRefs = 1;
-    ref->m_referencedName = &name;
+    ref->m_referencedName = new Name*[1]{name};
 
     Value *data = ValueAllocator::allocPrimData( Value::ddl_ref );
     data->setRef( ref );
@@ -224,6 +222,9 @@ TEST_F( ValueTest, accessReferenceTest ) {
         EXPECT_EQ( orig->m_type, newName->m_type );
         EXPECT_EQ( *orig->m_id, *newName->m_id );
     }
+    delete ref;
+    delete data;
+
 }
 
 TEST_F(ValueTest, sizeTest) {
@@ -236,8 +237,7 @@ TEST_F(ValueTest, sizeTest) {
     size = data1->size();
     EXPECT_EQ(2, size);
 
-    ValueAllocator::releasePrimData(&data2);
-    ValueAllocator::releasePrimData(&data1);
+    delete data1;
 }
 
 END_ODDLPARSER_NS

--- a/test/ValueTest.cpp
+++ b/test/ValueTest.cpp
@@ -211,7 +211,8 @@ TEST_F( ValueTest, accessReferenceTest ) {
     Reference *ref = new Reference;
     Name *name = new Name( GlobalName, new Text( "hello", 4 ) );
     ref->m_numRefs = 1;
-    ref->m_referencedName = new Name*[1]{name};
+    ref->m_referencedName = new Name*[1];
+    ref->m_referencedName[0]=name;
 
     Value *data = ValueAllocator::allocPrimData( Value::ddl_ref );
     data->setRef( ref );


### PR DESCRIPTION
Don't be afraid to use the delete operator sometimes ;)
``
valgrind bin/openddl_parser_demo --file test/example/Example.ogex 
``
Before:
  ==16898== HEAP SUMMARY:
  ==16898==     in use at exit: 20,187 bytes in 725 blocks 
  ==16898==   total heap usage: 864 allocs, 139 frees, 37,817 bytes allocated

After:
  ==16779== HEAP SUMMARY:
  ==16779==     in use at exit: 0 bytes in 0 blocks
  ==16779==   total heap usage: 860 allocs, 860 frees, 37,753 bytes allocated

the test run correctly but still 1 memory leak..

you should consider to use c++11 unique_ptr/share_ptr for simplify the things.. 