### PR TITLE
Optional: Premade logger

### DIFF
--- a/code/OpenDDLParser.cpp
+++ b/code/OpenDDLParser.cpp
@@ -132,6 +132,24 @@ OpenDDLParser::~OpenDDLParser() {
     clear();
 }
 
+void OpenDDLParser::logToStream(FILE *f, LogSeverity severity, const std::string &message) {
+    if (f) {
+        const char *tag = "none";
+        switch (severity) {
+        case ddl_debug_msg: tag = "debug"; break;
+        case ddl_info_msg:  tag = "info";  break;
+        case ddl_warn_msg:  tag = "warn";  break;
+        case ddl_error_msg: tag = "error"; break;
+        }
+        fprintf(f, "OpenDDLParser: (%5s) %s\n", tag, message.c_str());
+    }
+}
+
+OpenDDLParser::logCallback OpenDDLParser::StdLogCallback (FILE *destination) {
+    using namespace std::placeholders;
+    return std::bind(logToStream, destination ? destination : stderr, _1, _2);
+}
+
 void OpenDDLParser::setLogCallback(logCallback callback) {
     // install user-specific log callback; null = no log callback
     m_logCallback = callback;

--- a/include/openddlparser/OpenDDLParser.h
+++ b/include/openddlparser/OpenDDLParser.h
@@ -29,6 +29,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <string>
 #include <vector>
+#include <functional>
 
 BEGIN_ODDLPARSER_NS
 
@@ -97,8 +98,8 @@ DLL_ODDLPARSER_EXPORT const char *getTypeToken(Value::ValueType type);
 //-------------------------------------------------------------------------------------------------
 class DLL_ODDLPARSER_EXPORT OpenDDLParser {
 public:
-    ///	@brief  The log callback function pointer.
-    typedef void (*logCallback)(LogSeverity severity, const std::string &msg);
+    ///	@brief  The log callback function.
+    typedef std::function<void (LogSeverity severity, const std::string &msg)> logCallback;
 
 public:
     ///	@brief  The default class constructor.
@@ -119,6 +120,11 @@ public:
     ///	@brief  Getter for the log callback.
     /// @return The current log callback.
     logCallback getLogCallback() const;
+
+    /// @brief  A default log callback that writes to a FILE.
+    /// @param  destination [in] Output stream. NULL will use stderr.
+    /// @return A callback that you can pass to setLogCallback.
+    static logCallback StdLogCallback(FILE *destination = nullptr);
 
     ///	@brief  Assigns a new buffer to parse.
     ///	@param  buffer      [in] The buffer
@@ -192,6 +198,9 @@ private:
     typedef std::vector<DDLNode *> DDLNodeStack;
     DDLNodeStack m_stack;
     Context *m_context;
+
+    ///	@brief  Callback for StdLogCallback(). Not meant to be called directly.
+    static void logToStream (FILE *, LogSeverity, const std::string &);
 };
 
 END_ODDLPARSER_NS

--- a/test/OpenDDLParserTest.cpp
+++ b/test/OpenDDLParserTest.cpp
@@ -132,15 +132,38 @@ TEST_F(OpenDDLParserTest, createTest) {
     EXPECT_TRUE(success);
 }
 
+
 TEST_F(OpenDDLParserTest, setLogCallbackTest) {
     OpenDDLParser myParser;
+    EXPECT_EQ(nullptr, myParser.getLogCallback());
+    EXPECT_THROW(myParser.getLogCallback()(ddl_info_msg, ""), std::bad_function_call);
 
+    typedef decltype(&OpenDDLParserTest::testLogCallback) cbType;
     myParser.setLogCallback(OpenDDLParserTest::testLogCallback);
-    EXPECT_EQ(&OpenDDLParserTest::testLogCallback, myParser.getLogCallback());
+    EXPECT_EQ(&OpenDDLParserTest::testLogCallback, *myParser.getLogCallback().target<cbType>());
+    EXPECT_NE(nullptr, myParser.getLogCallback());
+    EXPECT_TRUE((bool)myParser.getLogCallback());
 
     myParser.setLogCallback(nullptr);
-    EXPECT_NE(&OpenDDLParserTest::testLogCallback, myParser.getLogCallback());
+    EXPECT_EQ(nullptr, myParser.getLogCallback());
+    EXPECT_FALSE((bool)myParser.getLogCallback());
+    EXPECT_THROW(myParser.getLogCallback()(ddl_info_msg, ""), std::bad_function_call);
 }
+
+
+TEST_F(OpenDDLParserTest, stdLogCallbackTest) {
+    OpenDDLParser myParser;
+    EXPECT_EQ(nullptr, myParser.getLogCallback());
+
+    myParser.setLogCallback(OpenDDLParser::StdLogCallback(stdout));
+    EXPECT_NE(nullptr, myParser.getLogCallback());
+    myParser.getLogCallback()(ddl_info_msg, "ddl_info_msg to stdout");
+
+    myParser.setLogCallback(OpenDDLParser::StdLogCallback(stderr));
+    EXPECT_NE(nullptr, myParser.getLogCallback());
+    myParser.getLogCallback()(ddl_info_msg, "ddl_info_msg to stderr");
+}
+
 
 TEST_F(OpenDDLParserTest, accessBufferTest) {
     static const size_t len = 100;


### PR DESCRIPTION
I felt bad leaving OpenDDLParser with no default logging whatsoever, so here's a second PR you can apply if you want. Or you can reject it. It's not related to (and won't affect) assimp.

---

It's still probably convenient to have a logger already written, so you don't have to write boilerplate code every time (since the default logger was removed).

To support this:
- The logCallback type has been upgraded to an std::function (so log callbacks can now be anything callable -- static functions, non-static member functions, structs with () operators, std::bind, etc.).
- Added OpenDDLParser::StdLogCallback(FILE*=nullptr) -- this provides a basic logger implementation that you can pass to setLogCallback.

The initial default logger is still a no-op, however, now you can do this instead of writing your own:

    OpenDDLParser myParser;
    myParser.setLogCallback( OpenDDLParser::StdLogCallback(stdout) );

Also updated unit test accordingly.