### PR TITLE
Add includes for installed cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ install(TARGETS openddlparser
         EXPORT  openddlparser-targets
         LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        INCLUDES      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/openddlparser")
 
 install(EXPORT openddlparser-targets


### PR DESCRIPTION
Add the `INCLUDES` directive to the `install(TARGETS)` commands. With it
the public include directories are populated for the installed targets.

This helps to make the installed package self sufficient, by telling the
using project all information it needs to use the
`openddlparser::openddlparser` target. A simple
`target_link_libraries()` is now enough to use the target. Previously
the include path had to be found with other means or already be included
in the parent project.