### PR TITLE
CMake: install dll into bin folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ include(CMakePackageConfigHelpers)
 
 install(TARGETS openddlparser
         EXPORT  openddlparser-targets
+        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
         LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"


### PR DESCRIPTION
Currently, dll file is not installed when openddl-parser is shared on Windows.