### PR TITLE
Fixed issue with clang complaining about sprintf being depreciated

### DIFF
--- a/code/OpenDDLExport.cpp
+++ b/code/OpenDDLExport.cpp
@@ -225,7 +225,7 @@ bool OpenDDLExport::writeValueType(Value::ValueType type, size_t numItems, std::
         statement += "[";
         char buffer[256];
         ::memset(buffer, '\0', 256 * sizeof(char));
-        sprintf(buffer, "%d", static_cast<int>(numItems));
+        snprintf(buffer, sizeof(buffer), "%d", static_cast<int>(numItems));
         statement += buffer;
         statement += "]";
     }
@@ -256,7 +256,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             std::stringstream stream;
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
-            sprintf(buffer, "%d", val->getInt16());
+            snprintf(buffer, sizeof(buffer), "%d", val->getInt16());
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int32: {
@@ -264,7 +264,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
             const int i = static_cast<int>(val->getInt32());
-            sprintf(buffer, "%d", i);
+            snprintf(buffer, sizeof(buffer), "%d", i);
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int64: {


### PR DESCRIPTION
Pushed upstream from https://github.com/assimp/assimp/commit/e2e45f7a145ec5867d3df324c8a4bc77817e2df6 and https://github.com/assimp/assimp/commit/38ccb7e6c9237a3528583684c0f49698b8fc156b