### PR TITLE
ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/openddl-parser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/openddl-parser

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+# Build project
+mkdir build
+cd build
+cmake ../
+make
+
+# Copy all fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE -stdlib=libc++ \
+  $SRC/openddl-parser/.clusterfuzzlite/parser_fuzzer.cpp \
+  -o $OUT/parser_fuzzer \
+  -I$SRC/openddl-parser/include \
+  $SRC/openddl-parser/build/lib/libopenddlparser.a

--- a/.clusterfuzzlite/parser_fuzzer.cpp
+++ b/.clusterfuzzlite/parser_fuzzer.cpp
@@ -1,3 +1,26 @@
+/*-----------------------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2023 Openddl-parser authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-----------------------------------------------------------------------------------------------*/
+
 #include <fuzzer/FuzzedDataProvider.h>
 #include <string>
 
@@ -14,3 +37,4 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     return 0;
 }
+

--- a/.clusterfuzzlite/parser_fuzzer.cpp
+++ b/.clusterfuzzlite/parser_fuzzer.cpp
@@ -1,0 +1,16 @@
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+
+#include <openddlparser/OpenDDLParser.h>
+#include <iostream>
+
+USE_ODDLPARSER_NS;
+
+extern "C" int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    OpenDDLParser theParser;
+    theParser.setBuffer((const char *)data, size);
+    theParser.parse();
+
+    return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 200
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets the parsing logic, and currently set the timeout of CFLite to 200 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.