### PR TITLE
Fix fuzzer finding in parse Interger literal

### DIFF
--- a/code/OpenDDLParser.cpp
+++ b/code/OpenDDLParser.cpp
@@ -696,7 +696,7 @@ char *OpenDDLParser::parseIntegerLiteral(char *in, char *end, Value **integer, V
 
     in = lookForNextToken(in, end);
     char *start(in);
-    while (!isSeparator(*in) && in != end) {
+    while (in != end && !isSeparator(*in)) {
         ++in;
     }
 
@@ -755,7 +755,7 @@ char *OpenDDLParser::parseFloatingLiteral(char *in, char *end, Value **floating,
     }
 
     // parse the float value
-    bool ok(false);
+    bool ok{false};
     if (isHexLiteral(start, end)) {
         parseHexaLiteral(start, end, floating);
         return in;


### PR DESCRIPTION
- closes https://github.com/kimkulling/openddl-parser/issues/85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a rare crash when parsing numeric values near the end of input.
  * Improved parser robustness by safely handling cases where optional parse targets aren’t available.

* **Refactor**
  * Applied minor consistency tweaks to parsing internals (initialization/condition ordering) with no user-facing behavior changes.

* **Chores**
  * Updated internal safety checks to improve reliability; no public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->